### PR TITLE
Revert "Refactored Slider on Homepage"

### DIFF
--- a/app/components/molecules/content-card.tsx
+++ b/app/components/molecules/content-card.tsx
@@ -1,57 +1,33 @@
-import {
-  View,
-  Image,
-  Modal,
-  TouchableOpacity,
-  StyleSheet,
-  TextInput,
-  ScrollView,
-  SafeAreaView,
-} from "react-native";
+import { View, Image, Modal, TouchableOpacity, StyleSheet, TextInput, ScrollView, SafeAreaView } from "react-native";
 import { useState } from "react";
-import tw from "twrnc";
-import React from "react";
+import tw from 'twrnc';
+import React from 'react';
 
-import { Avatar, Button, Card, Text, Snackbar } from "react-native-paper";
+import { Avatar, Button, Card, Text, Snackbar } from 'react-native-paper';
 import { router } from "expo-router";
 // const LeftContent = (props: any) => <Avatar.Icon {...props} icon="folder" />
 
-export default function ContentCard({
-  imgSrc,
-  data,
-  heading,
-  snippet,
-  onToggleSnackBar,
-}: {
-  imgSrc: string;
-  data: any;
-  heading: string;
-  snippet: string;
-  onToggleSnackBar: any;
-}) {
-  // const [visible, setVisible] = useState(false);
+export default function ContentCard({ imgSrc, data, heading, snippet, onToggleSnackBar }: { imgSrc: string, data: any, heading: string, snippet: string, onToggleSnackBar: any }) {
+        // const [visible, setVisible] = useState(false);
 
-  // const onToggleSnackBar = () => setVisible(!visible);
+        // const onToggleSnackBar = () => setVisible(!visible);
 
-  // const onDismissSnackBar = () => setVisible(false);
-  // // onPress = { onToggleSnackBar } > { visible? 'Hide': 'Show' }
-  return (
-    <View style={tw.style("text-white w-50 p-2")}>
-      <TouchableOpacity
-        style={tw.style("text-white")}
-        onPress={() => onToggleSnackBar(data)}
-      >
-        <Card style={tw.style(`mt-4 bg-[#001D3D] p-2`)}>
-          <Card.Cover
-            style={tw.style(`p-2 h-35 bg-[#001D3D]`)}
-            source={{ uri: imgSrc }}
-          />
-          <Text style={tw.style("text-white p-4")}>{heading}</Text>
-          {/* <Card.Content style={tw.style("text-white")}>
-            <Text style={tw.style("text-white")}>{snippet}</Text>
-          </Card.Content> */}
-        </Card>
-      </TouchableOpacity>
-    </View>
-  );
+        // const onDismissSnackBar = () => setVisible(false);
+        // // onPress = { onToggleSnackBar } > { visible? 'Hide': 'Show' }
+        return (
+                <View>
+                        <TouchableOpacity
+                                onPress={() => onToggleSnackBar(data)}
+                        >
+                                <Card style={tw.style(`w-[14rem]`, `m-2`, `bg-white`)}>
+                                        <Card.Cover style={tw.style(`p-2`, `bg-white`)} source={{ uri: imgSrc }} />
+                                        <Card.Title title={heading} />
+                                        <Card.Content>
+                                                <Text>{snippet}</Text>
+                                        </Card.Content>
+                                </Card>
+                        </TouchableOpacity>
+
+                </View>
+        )
 }

--- a/app/components/molecules/slider.tsx
+++ b/app/components/molecules/slider.tsx
@@ -19,8 +19,9 @@ export default function Slider({
       horizontal
       showsHorizontalScrollIndicator={false}
       scrollEventThrottle={10}
-      // pagingEnabled
-      // contentContainerStyle={{ justifyContent: "center" }}
+      pagingEnabled
+      style={{ padding: 10 }}
+      contentContainerStyle={{ justifyContent: "center" }}
     >
       {data.map((item, i) => {
         const displayData =


### PR DESCRIPTION
Reverting changes to the slider in light of a larger UI redesign that needs to occur on the dashboard. Current points of change are:

- Universal height for news card
- Border around the integrated map to match contrast of oxford blue in color palette
- Resize and space around navbar items to remove unnecessary whitespace
- Implement skeletons for logo, map, news slider and navbar to remove UI reshuffle on element/data load