### PR TITLE
Huge Usability Improvements on Reporting Alerts  - Swal Like Report Alert Confirmations

### DIFF
--- a/app/components/dashboard/dashboard.tsx
+++ b/app/components/dashboard/dashboard.tsx
@@ -125,7 +125,7 @@ export default function Dashboard({
         </View>
         <View style={tw.style(`flex`)}>
           <View style={tw.style("border-solid border-[3] rounded-md border-[#001D3D]")}>
-            <MapComp pitchEnabled={false} scrollEnabled={false} toolbarEnabled={false} height={300} />
+            <MapComp zoomEnabled={false} pitchEnabled={false} scrollEnabled={false} toolbarEnabled={false} height={300} />
           </View>
           <Pressable
             onPress={() => {

--- a/app/map.tsx
+++ b/app/map.tsx
@@ -19,7 +19,7 @@ export default function App() {
 
   return (
     <View style={tw.style(`h-full`, `relative`)}>
-      <MapComp pitchEnabled={true} scrollEnabled={true} toolbarEnabled={true} buttons={true} />
+      <MapComp zoomEnabled={true} pitchEnabled={true} scrollEnabled={true} toolbarEnabled={true} buttons={true} />
       {/* <Footer /> */}
     </View>
   );

--- a/utils/static-types.ts
+++ b/utils/static-types.ts
@@ -87,6 +87,7 @@ export type MapCompProps = {
   scrollEnabled?: boolean;
   pitchEnabled?:boolean;
   toolbarEnabled?:boolean;
+  zoomEnabled?:boolean;
 };
 
 export type LocationData = {


### PR DESCRIPTION
My previous PR handled retrieving alerts from the backend.

This one handled POSTing the alerts to the backend and handling it on the front end with a nice usability improvement being the swal like confirmation alerts. images are attached.

Action: User reported alert
![image](https://github.com/OurSoS/OurSoS-Uno/assets/53635108/a5978f32-b6e4-4347-b401-116be620ac88)

Action: User Drags alert
![image](https://github.com/OurSoS/OurSoS-Uno/assets/53635108/9a9fb174-6473-4073-b8c7-b028386ae741)

If user hits CANCEL => the marker is removed right away with a confirmation
![image](https://github.com/OurSoS/OurSoS-Uno/assets/53635108/47b27502-9078-4a32-94d0-27b089a88e94)

If user hits CONFIRM REPORT => the marker is then added with the proper severity color and shows a confirmation
![image](https://github.com/OurSoS/OurSoS-Uno/assets/53635108/cb5c8364-5440-40eb-a53d-3a81cb56f400)

