### PR TITLE
Languages are now from a preset list of 5 + Intro/Dashboard conditional view

### DIFF
--- a/app/components/modalCreateAlerts.tsx
+++ b/app/components/modalCreateAlerts.tsx
@@ -130,7 +130,7 @@ const ModalCreateAlerts = React.memo((props: modalCreateAlertsProps) => {
         <Text style={tw.style("text-white")}>Back</Text>
       </Pressable>
       {view === 1 && (
-        <View style={tw.style("flex h-full flex-grow justify-center")}>
+        <View style={tw.style("flex h-full flex-grow justify-center pb-10")}>
           <Text> Page 1/3</Text>
           <Text style={tw.style("text-3xl text-center mt-10 mb-10")}>
             What did you see?
@@ -211,7 +211,7 @@ const ModalCreateAlerts = React.memo((props: modalCreateAlertsProps) => {
       )}
 
       {view === 2 && (
-        <View style={tw.style("flex h-full flex-grow justify-center")}>
+        <View style={tw.style("flex h-full flex-grow justify-center pb-10")}>
           <Text style={tw.style("")}> Page 2/3</Text>
           <Text style={tw.style("text-3xl text-center mt-10 mb-10")}>
             Tell us more
@@ -249,7 +249,7 @@ const ModalCreateAlerts = React.memo((props: modalCreateAlertsProps) => {
       )}
 
       {view === 3 && (
-        <View style={tw.style("flex h-full flex-grow justify-center")}>
+        <View style={tw.style("flex h-full flex-grow justify-center pb-10")}>
           <Text> Page 3/3</Text>
           <Text style={tw.style("text-3xl text-center mt-10 mb-10")}>
             {selectedCategory}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -32,7 +32,7 @@ LogBox.ignoreAllLogs(); //Ignore all log notifications
 type alert = {
   id?: number;
   message?: string;
-  category: string;
+  type: string;
   lat: Float;
   long: Float;
   radius?: Float;
@@ -200,11 +200,30 @@ export default function Index() {
           }
         });
 
-      await axios
-        .get("https://oursos-backend-production.up.railway.app/languages")
-        .then((res) => {
-          setLanguages(res.data);
-        });
+      
+        setLanguages([
+          {
+            "name": "Polski",
+            "tag": "pl"
+          },
+          {
+            "name": "简体中文）",
+            "tag": "zh"
+          },
+          {
+            "name": "Français",
+            "tag": "fr"
+          },
+          {
+            "name": "Italiano",
+            "tag": "it"
+          },
+          {
+            "name": "नहीं",
+            "tag": "hi"
+          },
+        ]);
+        
 
       let { status } = await Location.requestForegroundPermissionsAsync();
       if (status !== "granted") {
@@ -330,11 +349,11 @@ export default function Index() {
         ++i;
         console.log(
           "==============alert================",
-          alert.category,
+          alert.type,
           alert.id
         );
         await sendLocalNotification(
-          `Emergency Alert: Immediate danger in your area due to a ${alert.category}.Seek safety immediately as per local guidelines and stay informed.`
+          `Emergency Alert: Immediate danger in your area due to a ${alert.type}.Seek safety immediately as per local guidelines and stay informed.`
         );
       }
     }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -127,7 +127,7 @@ export default function Index() {
   const [translatedStaticContent, setTranslatedStaticContent] =
     useState<any>(staticText);
   const [userLang, setUserLang] = useState("hi");
-  const [introComponent, setIntroComponent] = useState("welcome");
+  const [introComponent, setIntroComponent] = useState("dashboard");
   const [languages, setLanguages] = useState<LanguageType[]>([]);
   const [location, setLocation] = useState<any>(null);
   const [errorMsg, setErrorMsg] = useState<string>("");
@@ -172,6 +172,8 @@ export default function Index() {
         .then((response) => response.json())
         .then((data) => {
           if (data === null) {
+            //IF the user does not exist, create a new user and display the INTRO rather than Dashboard.
+            setIntroComponent("welcome");
             let userData = {
               deviceId: deviceId,
               username: deviceId,
@@ -197,6 +199,8 @@ export default function Index() {
               .catch((error) => {
                 console.error("Error:", error);
               });
+          } else {
+            setIntroComponent("dashboard");
           }
         });
 

--- a/app/selectLanguage.tsx
+++ b/app/selectLanguage.tsx
@@ -34,23 +34,42 @@ export default function SelectLanguages() {
 
   useEffect(() => {
     (async () => {
-      await axios
-        .get("https://oursos-backend-production.up.railway.app/languages")
-        .then((res) => {
-          setLanguages(res.data);
-        });
+     
+          setLanguages([
+            {
+              "name": "Polski",
+              "tag": "pl"
+            },
+            {
+              "name": "简体中文）",
+              "tag": "zh"
+            },
+            {
+              "name": "Français",
+              "tag": "fr"
+            },
+            {
+              "name": "Italiano",
+              "tag": "it"
+            },
+            {
+              "name": "नहीं",
+              "tag": "hi"
+            },
+          ]);
+       
     })();
   }, []);
 
-  useEffect(() => {
-    (async () => {
-      await axios
-        .get("https://oursos-backend-production.up.railway.app/languages")
-        .then((res) => {
-          setLanguages(res.data);
-        });
-    })();
-  }, []);
+  // useEffect(() => {
+  //   (async () => {
+  //     await axios
+  //       .get("https://oursos-backend-production.up.railway.app/languages")
+  //       .then((res) => {
+  //         setLanguages(res.data);
+  //       });
+  //   })();
+  // }, []);
 
   return (
     <>


### PR DESCRIPTION
Due to our translation API costing money, we have to set our available languages to a small amount and cache them with redis. 

right now are languages are:

Polish
Mandarin
Hindi
Italian
French

I also made the Intro page show depending on if the user exists or not, if the user does not currently exist in our database it will show the intro first, if the user exists, it will show the dashboard.

also fixed the button padding bottom that somehow dissapeared from previous merges.